### PR TITLE
Python docstrings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"] # To sync with coveragerc use 3 level
+        python-version: ["3.10", "3.11", "3.12", "3.13"] # To sync with coveragerc use 3 level
 
     steps:
     # First print out lots of information. We do this in separate
@@ -54,32 +54,28 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: which python3 after python setup
-      run: which python3
-
-    - name: which pip after python setup
+    - name: which python after python setup
       run: |
-        python -m pip install --upgrade pip
-        pip --version
+        which python
+        python --version
 
-    - name: env after adding python
-      run: env
+    - name: Ensure pip is installed
+      run: |
+        python -m ensurepip --upgrade
+        python -m pip install --upgrade pip
+
+    - name: Verify pip
+      run: python -m pip --version
 
     - name: Install python dependencies
       run: |
-        pip install wheel numpy cmake ninja scipy
-
-    - name: Add to LD_LIBRARY_PATH so scalapack etc can be found
-      run: echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
-
-    - name: env after adding to LD_LIBRARY_PATH
-      run: env
+        python -m pip install wheel numpy cmake ninja scipy
 
     - name: Install virtual-casing package
-      run: pip install -v .
+      run: python -m pip install -v .
 
     - name: Run tests
       run: |
         cd test
-        python3 -m unittest -v test.py
+        python -m unittest -v test.py
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -18,9 +18,9 @@ jobs:
             deployment_target: 14
             arch_flag: "-mcpu=apple-m1"
 
-          - runner: macos-13 # x86_64
-            deployment_target: 13
-            arch_flag: "-march=ivybridge"
+          - runner: macos-15 # arm64
+            deployment_target: 15
+            arch_flag: "-mcpu=apple-m1"
 
     steps:
       - name: Checkout repository
@@ -42,20 +42,20 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ENVIRONMENT_LINUX: CI=True VC_ARCH_FLAG=${{ matrix.arch_flag }}
           CIBW_BEFORE_ALL_LINUX: yum install -y lapack-devel openblas-devel fftw-devel
-          CIBW_BEFORE_BUILD_LINUX: pip install --upgrade pip setuptools wheel numpy cmake ninja && git config --global --add safe.directory /project
+          CIBW_BEFORE_BUILD_LINUX: python -m pip install --upgrade pip setuptools wheel numpy cmake ninja && git config --global --add safe.directory /project
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_SKIP: "*-musllinux_*"
           CIBW_ENVIRONMENT_MACOS: CI=True VC_ARCH_FLAG=${{ matrix.arch_flag }} MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }} CC=gcc-12 CXX=g++-12 # with GCC
           #CIBW_ENVIRONMENT_MACOS: CI=True VC_ARCH_FLAG=${{ matrix.arch_flat }} MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }} OpenMP_ROOT=$(brew --prefix)/opt/libomp # with Apple Clang
           CIBW_BEFORE_ALL_MACOS: brew install fftw lapack gcc@12 libomp openblas
-          CIBW_BEFORE_BUILD_MACOS: pip install --upgrade pip setuptools wheel numpy cmake ninja && git config --global --add safe.directory /project
-          CIBW_BUILD : cp38-* cp39-* cp310-* cp311-*
+          CIBW_BEFORE_BUILD_MACOS: python -m pip install --upgrade pip setuptools wheel numpy cmake ninja && git config --global --add safe.directory /project
+          CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
 
       - name: Debug with tmate on failure
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
         with:
-          timeout: 900  # 15 minutes
+          timeout-minutes: 15
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       # - name: Install setuptools_scm
       #   run: python -m pip install setuptools_scm

--- a/README.md
+++ b/README.md
@@ -25,11 +25,20 @@ If the compilation is successful, you will have ``vc_testing`` in the ``build`` 
 
 ### Python package
 
-We also need ninja package, which can be installed with pip
+To install the python package use pip:
 
-    pip install ninja
-  
-Then run 
+    python -m pip install .
 
-    python setup.py install
+To build the wheel use:
 
+    python -m build --wheel
+
+which can be installed by:
+
+    pip install dist/virtual_casing*.whl
+
+## Testing
+
+Run the tests using
+
+    python -m unittest test -v

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -8,6 +8,7 @@ namespace py = pybind11;
 
 
 PYBIND11_MODULE(virtual_casing, m) {
+    m.doc() = "Virtual casing principle for magnetic field computation.";
 
     py::class_<sctl::Vector<double>>(m, "SCTLDoubleVector")
          .def(py::init<>())
@@ -17,7 +18,8 @@ PYBIND11_MODULE(virtual_casing, m) {
         .def(py::init<>())
         .def(py::init<const std::vector<int> & >());
 
-    py::enum_<biest::SurfType>(m, "SurfType")
+    py::enum_<biest::SurfType>(m, "SurfType",
+        "Prebuilt surface geometry types for testing.")
         .value("AxisymCircleWide", biest::SurfType::AxisymCircleWide)           // 125 x 50
         .value("AxisymCircleNarrow", biest::SurfType::AxisymCircleNarrow)       // 250 x 50
         .value("AxisymWide", biest::SurfType::AxisymWide)                       // 125 x 50
@@ -30,20 +32,268 @@ PYBIND11_MODULE(virtual_casing, m) {
         .value("Stell", biest::SurfType::Stell)                                 // 250 x 50
         .value("W7X_", biest::SurfType::W7X_);
 
-    py::class_<VirtualCasing<double>>(m, "VirtualCasing")
+    py::class_<VirtualCasing<double>>(m, "VirtualCasing",
+        "Compute the external or internal magnetic field using the virtual casing principle.")
         .def(py::init<>())
-        .def("setup", &VirtualCasing<double>::Setup)
-        .def("compute_external_B", &VirtualCasing<double>::ComputeBext)
-        .def("compute_external_B_offsurf", &VirtualCasing<double>::ComputeBextOffSurf)
-        .def("compute_external_gradB", &VirtualCasing<double>::ComputeGradBext)
-        .def("compute_internal_B", &VirtualCasing<double>::ComputeBint)
-        .def("compute_internal_B_offsurf", &VirtualCasing<double>::ComputeBintOffSurf);
+        .def("setup", &VirtualCasing<double>::Setup,
+            R"pbdoc(
+            Setup the VirtualCasing object.
 
-    py::class_<VirtualCasingTestData<double>>(m, "VirtualCasingTestData")
+            Parameters
+            ----------
+            digits : int
+                Number of decimal digits of accuracy.
+            NFP : int
+                Number of toroidal field periods. The surface as well as the
+                magnetic field must have this toroidal periodic symmetry.
+            half_period : bool
+                Whether the surface and data are defined on half field period.
+            Nt : int
+                Surface discretization order in toroidal direction (in one field period).
+            Np : int
+                Surface discretization order in poloidal direction.
+            X : list of float
+                The surface coordinates in the order {x11, x12, ..., x1Np,
+                x21, x22, ..., xNtNp, y11, ..., z11, ...}.
+            src_Nt : int
+                Input B-field discretization order in toroidal direction (in one field period).
+            src_Np : int
+                Input B-field discretization order in poloidal direction.
+            trg_Nt : int, optional
+                Output Bext-field discretization order in toroidal direction
+                (in one field period). Default is -1 (same as src_Nt).
+            trg_Np : int, optional
+                Output Bext-field discretization order in poloidal direction.
+                Default is -1 (same as src_Np).
+
+            Notes
+            -----
+            The grids for input and output data differ depending on whether
+            stellarator symmetry is exploited (half_period). For this discussion,
+            consider the toroidal angle phi and poloidal angle theta to have
+            period 1 (not 2*pi).
+
+            If half_period is False, the grids in toroidal angles begin at phi=0.
+            The grid spacing is 1/(NFP*Nt), with no point at phi = 1/NFP.
+
+            If half_period is True, the toroidal grids are shifted by half a grid
+            point, so there is no grid point at phi=0. The phi grid for the surface
+            has points at 0.5/(NFP*Nt), 1.5/(NFP*Nt), ..., (Nt-0.5)/(NFP*Nt).
+
+            The poloidal grid always ranges uniformly over [0, 1), with the first
+            grid point at theta=0 and no grid point at theta=1.
+
+            The resolution parameters for the surface shape (Nt, Np), input magnetic
+            field (src_Nt, src_Np), and output external field (trg_Nt, trg_Np) do
+            not need to be related to each other in any particular way.
+            )pbdoc")
+        .def("compute_external_B", &VirtualCasing<double>::ComputeBext,
+            R"pbdoc(
+            Compute the magnetic field due to currents external to the surface.
+
+            Recover the Bext component from the total field B = Bext + Bint:
+            Bext = B/2 + gradG[B . n] + BiotSavart[n x B]
+
+            Here, Bext is the magnetic field due to currents in the exterior of the
+            surface, and Bint is the magnetic field due to currents in the interior.
+
+            Parameters
+            ----------
+            B : list of float
+                The total magnetic field on the surface due to all currents.
+                B = {Bx11, Bx12, ..., Bx1Np, Bx21, Bx22, ..., BxNtNp, By11, ..., Bz11, ...},
+                where Nt and Np are the number of discretizations in toroidal and
+                poloidal directions.
+
+            Returns
+            -------
+            list of float
+                The component of magnetic field on the surface due to currents in
+                the exterior of the surface.
+            )pbdoc")
+        .def("compute_external_B_offsurf", &VirtualCasing<double>::ComputeBextOffSurf,
+            R"pbdoc(
+            Compute the magnetic field due to currents external to the surface at off-surface points.
+
+            Recover the Bext component from the total field B = Bext + Bint:
+            Bext = gradG[B . n] + BiotSavart[n x B]
+
+            Parameters
+            ----------
+            B : list of float
+                The total magnetic field on the surface due to all currents.
+                B = {Bx11, Bx12, ..., Bx1Np, Bx21, Bx22, ..., BxNtNp, By11, ..., Bz11, ...}.
+            Xt : list of float
+                The coordinates for off-surface evaluation points in the order
+                {x1, x2, ..., xn, y1, ..., z1, ..., zn}.
+            max_Nt : int, optional
+                Restrict upsampling to max_Nt modes (in a field-period) in toroidal
+                direction. Default is -1 (no restriction).
+            max_Np : int, optional
+                Restrict upsampling to max_Np modes in poloidal direction.
+                Default is -1 (no restriction).
+
+            Returns
+            -------
+            list of float
+                The component of magnetic field at the evaluation points due to
+                currents in the exterior of the surface.
+            )pbdoc")
+        .def("compute_external_gradB", &VirtualCasing<double>::ComputeGradBext,
+            R"pbdoc(
+            Compute the gradient of the magnetic field due to currents external to the surface.
+
+            Recover GradBext from the total field B = Bext + Bint using the
+            virtual casing principle.
+
+            Parameters
+            ----------
+            B : list of float
+                The total magnetic field on the surface due to all currents.
+                B = {Bx11, Bx12, ..., Bx1Np, Bx21, Bx22, ..., BxNtNp, By11, ..., Bz11, ...}.
+
+            Returns
+            -------
+            list of float
+                The gradient of the magnetic field component on the surface due to
+                currents in the exterior of the surface.
+            )pbdoc")
+        .def("compute_internal_B", &VirtualCasing<double>::ComputeBint,
+            R"pbdoc(
+            Compute the magnetic field due to currents internal to the surface.
+
+            Recover the Bint component from the total field B = Bext + Bint:
+            Bint = B/2 - gradG[B . n] - BiotSavart[n x B]
+
+            Here, Bext is the magnetic field due to currents in the exterior of the
+            surface, and Bint is the magnetic field due to currents in the interior.
+
+            Parameters
+            ----------
+            B : list of float
+                The total magnetic field on the surface due to all currents.
+                B = {Bx11, Bx12, ..., Bx1Np, Bx21, Bx22, ..., BxNtNp, By11, ..., Bz11, ...}.
+
+            Returns
+            -------
+            list of float
+                The component of magnetic field on the surface due to currents in
+                the interior of the surface.
+            )pbdoc")
+        .def("compute_internal_B_offsurf", &VirtualCasing<double>::ComputeBintOffSurf,
+            R"pbdoc(
+            Compute the magnetic field due to currents internal to the surface at off-surface points.
+
+            Recover the Bint component from the total field B = Bext + Bint.
+
+            Parameters
+            ----------
+            B : list of float
+                The total magnetic field on the surface due to all currents.
+                B = {Bx11, Bx12, ..., Bx1Np, Bx21, Bx22, ..., BxNtNp, By11, ..., Bz11, ...}.
+            Xt : list of float
+                The coordinates for off-surface evaluation points in the order
+                {x1, x2, ..., xn, y1, ..., z1, ..., zn}.
+            max_Nt : int, optional
+                Restrict upsampling to max_Nt modes (in a field-period) in toroidal
+                direction. Default is -1 (no restriction).
+            max_Np : int, optional
+                Restrict upsampling to max_Np modes in poloidal direction.
+                Default is -1 (no restriction).
+
+            Returns
+            -------
+            list of float
+                The component of magnetic field at the evaluation points due to
+                currents in the interior of the surface.
+            )pbdoc");
+
+    py::class_<VirtualCasingTestData<double>>(m, "VirtualCasingTestData",
+        "Generate test data for class VirtualCasing.")
         .def(py::init<>())
-        .def_static("surface_coordinates", &VirtualCasingTestData<double>::SurfaceCoordinates)
-        .def_static("magnetic_field_data", &VirtualCasingTestData<double>::BFieldData)
-        .def_static("magnetic_field_grad_data", &VirtualCasingTestData<double>::GradBFieldData);
+        .def_static("surface_coordinates", &VirtualCasingTestData<double>::SurfaceCoordinates,
+            R"pbdoc(
+            Generate nodal coordinates for toroidal surfaces.
+
+            Parameters
+            ----------
+            NFP : int
+                Number of toroidal field periods.
+            half_period : bool
+                Whether the returned surface coordinates should be on half field period.
+            Nt : int
+                Surface discretization order in toroidal direction (in one field period).
+            Np : int
+                Surface discretization order in poloidal direction.
+            surf_type : SurfType, optional
+                Prebuilt surface geometry type. Default is SurfType.AxisymNarrow.
+                Possible values: AxisymCircleWide, AxisymCircleNarrow, AxisymWide,
+                AxisymNarrow, RotatingEllipseWide, RotatingEllipseNarrow, Quas3,
+                LHD, W7X, Stell.
+
+            Returns
+            -------
+            list of float
+                The surface coordinates in the order {x11, x12, ..., x1Np,
+                x21, x22, ..., xNtNp, y11, ..., z11, ...}. The coordinates
+                correspond to the surface in the toroidal angle interval [0, 2*pi/NFP).
+            )pbdoc")
+        .def_static("magnetic_field_data", &VirtualCasingTestData<double>::BFieldData,
+            R"pbdoc(
+            Generate B field data for testing with class VirtualCasing.
+
+            Parameters
+            ----------
+            NFP : int
+                Number of toroidal field periods.
+            half_period : bool
+                Whether the result should be on half field period.
+            Nt : int
+                Surface discretization order in toroidal direction (in one field period).
+            Np : int
+                Surface discretization order in poloidal direction.
+            X : list of float
+                The surface coordinates in the order {x11, x12, ..., x1Np,
+                x21, x22, ..., xNtNp, y11, ..., z11, ...}.
+            trg_Nt : int
+                Output B-field discretization order in toroidal direction (in one field period).
+            trg_Np : int
+                Output B-field discretization order in poloidal direction.
+
+            Returns
+            -------
+            tuple of (list of float, list of float)
+                Bext and Bint, magnetic fields generated by an internal current loop
+                and an external current loop respectively.
+            )pbdoc")
+        .def_static("magnetic_field_grad_data", &VirtualCasingTestData<double>::GradBFieldData,
+            R"pbdoc(
+            Generate gradient of B field data for testing with class VirtualCasing.
+
+            Parameters
+            ----------
+            NFP : int
+                Number of toroidal field periods.
+            half_period : bool
+                Whether the result should be on half field period.
+            Nt : int
+                Surface discretization order in toroidal direction (in one field period).
+            Np : int
+                Surface discretization order in poloidal direction.
+            X : list of float
+                The surface coordinates in the order {x11, x12, ..., x1Np,
+                x21, x22, ..., xNtNp, y11, ..., z11, ...}.
+            trg_Nt : int
+                Output B-field discretization order in toroidal direction (in one field period).
+            trg_Np : int
+                Output B-field discretization order in poloidal direction.
+
+            Returns
+            -------
+            tuple of (list of float, list of float)
+                GradBext and GradBint, gradients of magnetic fields generated by an
+                internal current loop and an external current loop respectively.
+            )pbdoc");
 
 }
 


### PR DESCRIPTION
Added docstrings to the python side.  

These were scraped from the C sources and added to the pybind functions using LLMs (life is too short to do this by hand, they were manually checked though). 

Since directly running setup.py is is deprecated the README was also updated to use the modern installation conventions, and ninja installation is automatically handled by it's inclusion in the TOML file.